### PR TITLE
feature: cdk deploy

### DIFF
--- a/dist/deploy.js
+++ b/dist/deploy.js
@@ -253,9 +253,15 @@ module.exports = (robot) => {
             const releaseUrl = `https://github.com/${GITHUB_ORG}/${repo}/releases/${tag}`;
             msg.send(`:rocket: Deploying \`${repo}\` → \`${env}\`\n` +
                 `Tag: \`${tag}\` | Commit: \`${commitSha.slice(0, 8)}\` | SHA256: \`${fileHash.slice(0, 12)}...\``);
-            // Pass the api.github.com asset URL (not the human-facing releaseUrl)
-            // because deploy.sh rejects anything outside api.github.com/repos/sonarmd/*.
-            await runDeploy(msg, robot, identifier, env, tag, assetUrl);
+            const deployPlan = await resolveDeployPlan({
+                identifier,
+                env,
+                tag,
+                artifactUrl: assetUrl,
+                assetPath,
+                stagingDir,
+            });
+            await runDeployPlan(msg, robot, identifier, deployPlan);
             cleanup(assetPath, stagingDir);
             return;
         }
@@ -274,28 +280,26 @@ module.exports = (robot) => {
         const releaseUrl = `https://github.com/${GITHUB_ORG}/${repo}/releases/${tag}`;
         robot.logger.info(`[deploy] fallback | env: ${env} | app: ${identifier} | ${releaseUrl}`);
         msg.send(`:rocket: Deploying \`${repo}\` → \`${env}\` (no structured tag — using latest)`);
-        await runDeploy(msg, robot, identifier, env, tag, releaseUrl);
+        await runDeployPlan(msg, robot, identifier, [
+            createDefaultDeployPlanItem(identifier, env, tag, releaseUrl),
+        ]);
     });
 };
 // ── Deploy execution ─────────────────────────────────────────────────────────
-async function runDeploy(msg, robot, identifier, env, tag, artifactUrl) {
+async function runDeployPlan(msg, robot, identifier, deployPlan) {
+    for (const item of deployPlan) {
+        await runDeployItem(msg, robot, identifier, item);
+    }
+}
+async function runDeployItem(msg, robot, identifier, planItem) {
     var _a;
     try {
         // deploy.sh contract (7 positional args — strict):
         //   <caller> <make_target> <deploy_tag> <artifact_url> <deploy_bundle> <deploy_hosts> <deploy_env>
-        //
-        // make_target follows the ${identifier}_${env} convention (e.g. cdk_stg,
-        // api_prd). deploy_bundle and deploy_hosts are unused by the cdk_*
-        // Makefile targets, so we pass empty strings. Non-cdk apps that DO
-        // consume those will need bundle/hosts added to the Slack trigger
-        // contract — out of scope for this fix.
-        const makeTarget = `${identifier}_${env}`;
-        const deployTag = tag || 'latest';
-        const deployBundle = '';
-        const deployHosts = '';
+        const { makeTarget, deployTag, artifactUrl, deployBundle, deployHosts, deployEnv, displayName, } = planItem;
         // Use execFile-style quoting via shell-escaping so empty positional
         // args survive. Quote every arg defensively.
-        const escape = (s) => `'${s.replace(/'/g, "'\\''")}'`;
+        const escape = shellEscape;
         const cmd = [
             'sudo', '--non-interactive',
             DEPLOY_SCRIPT,
@@ -305,24 +309,135 @@ async function runDeploy(msg, robot, identifier, env, tag, artifactUrl) {
             escape(artifactUrl),
             escape(deployBundle),
             escape(deployHosts),
-            escape(env),
+            escape(deployEnv),
         ].join(' ');
         robot.logger.info(`[deploy] exec: ${cmd}`);
         const { stdout, stderr } = await exec(cmd, { timeout: DEPLOY_TIMEOUT });
         if (stderr)
             robot.logger.info(`[deploy] stderr: ${stderr}`);
         const recap = extractRecap(stdout);
-        msg.send(`:white_check_mark: Deploy SUCCESS — \`${identifier}\` \`${tag || 'latest'}\` → \`${env}\`\n` +
+        msg.send(`:white_check_mark: Deploy SUCCESS — \`${identifier}\` \`${deployTag || 'latest'}\` → \`${deployEnv}\` (${displayName})\n` +
             `\`\`\`\n${recap}\n\`\`\``);
     }
     catch (err) {
         robot.logger.error(`[deploy] failed: ${err.message}`);
         const tail = ((_a = err.stdout) !== null && _a !== void 0 ? _a : '').split('\n').slice(-30).join('\n');
-        msg.send(`:x: Deploy FAILED — \`${identifier}\` \`${tag || 'latest'}\` → \`${env}\`\n` +
+        msg.send(`:x: Deploy FAILED — \`${identifier}\` \`${planItem.deployTag || 'latest'}\` → \`${planItem.deployEnv}\` (${planItem.displayName})\n` +
             `\`\`\`\n${tail || err.stderr || err.message}\n\`\`\``);
     }
 }
 // ── Helpers ──────────────────────────────────────────────────────────────────
+async function resolveDeployPlan(params) {
+    const fallbackItem = createDefaultDeployPlanItem(params.identifier, params.env, params.tag, params.artifactUrl);
+    const manifest = await readReleaseManifest(params.assetPath, params.stagingDir);
+    if (manifest) {
+        const manifestPlan = await resolveManifestDeployPlan({
+            env: params.env,
+            tag: params.tag,
+            artifactUrl: params.artifactUrl,
+            stagingDir: params.stagingDir,
+        }, manifest);
+        if (manifestPlan.length > 0) {
+            return manifestPlan;
+        }
+    }
+    return [fallbackItem];
+}
+function createDefaultDeployPlanItem(identifier, env, tag, artifactUrl) {
+    return {
+        makeTarget: `${identifier}_${env}`,
+        deployTag: tag || 'latest',
+        artifactUrl,
+        deployBundle: '',
+        deployHosts: '',
+        deployEnv: env,
+        displayName: `${identifier}_${env}`,
+    };
+}
+async function resolveManifestDeployPlan(params, manifest) {
+    const extractedReleaseDir = path.join(params.stagingDir, 'release');
+    const planItems = [];
+    for (const bundle of manifest.bundles.filter(requiresPreparedDeployTarget)) {
+        const bundleArchive = path.join(extractedReleaseDir, `${bundle.name}.tar.gz`);
+        if (!(0, fs_1.existsSync)(bundleArchive)) {
+            throw new Error(`Missing bundle archive for ${bundle.name}`);
+        }
+        const bundleExtractDir = path.join(params.stagingDir, `bundle-${bundle.name}`);
+        await extractTarball(bundleArchive, bundleExtractDir);
+        const bundleRoot = path.join(bundleExtractDir, normalizeBundleRoot(bundle.path));
+        for (const host of bundle.hosts) {
+            const deployHost = renderDeployHost(host, params.env);
+            const templateSource = path.join(bundleRoot, `${deployHost}.template.json`);
+            if (!(0, fs_1.existsSync)(templateSource)) {
+                throw new Error(`Missing CDK template for ${deployHost} in ${bundle.name}`);
+            }
+            const preparedDir = path.join(DEPLOY_CACHE_BASE, params.tag, deployHost, params.env);
+            (0, fs_1.mkdirSync)(preparedDir, { recursive: true });
+            (0, fs_1.copyFileSync)(templateSource, path.join(preparedDir, `${deployHost}.template.json`));
+            planItems.push({
+                makeTarget: `${bundle.target}_${params.env}`,
+                deployTag: params.tag || 'latest',
+                artifactUrl: params.artifactUrl,
+                deployBundle: bundle.name,
+                deployHosts: deployHost,
+                deployEnv: params.env,
+                displayName: `${bundle.name}:${deployHost}`,
+            });
+        }
+    }
+    return dedupeDeployPlan(planItems);
+}
+async function readReleaseManifest(assetPath, stagingDir) {
+    const extractedReleaseDir = path.join(stagingDir, 'release');
+    const manifestPath = path.join(extractedReleaseDir, 'deploy.json');
+    if (!(0, fs_1.existsSync)(manifestPath)) {
+        await extractTarball(assetPath, extractedReleaseDir);
+    }
+    if (!(0, fs_1.existsSync)(manifestPath)) {
+        return null;
+    }
+    return readDeployManifest(manifestPath);
+}
+function readDeployManifest(filePath) {
+    const manifest = JSON.parse((0, fs_1.readFileSync)(filePath, 'utf8'));
+    if (!Array.isArray(manifest.bundles)) {
+        throw new Error(`Invalid deploy manifest at ${filePath}`);
+    }
+    return manifest;
+}
+async function extractTarball(archivePath, destination) {
+    (0, fs_1.mkdirSync)(destination, { recursive: true });
+    await exec(`tar -xzf ${shellEscape(archivePath)} -C ${shellEscape(destination)}`, { timeout: DEPLOY_TIMEOUT });
+}
+function normalizeBundleRoot(bundlePath) {
+    return path.basename(bundlePath.replace(/[\\/]+$/, ''));
+}
+function renderDeployHost(host, env) {
+    return host.replace(/\{env\}/g, env);
+}
+function requiresPreparedDeployTarget(bundle) {
+    return bundle.target === 'cdk';
+}
+function dedupeDeployPlan(items) {
+    const seen = new Set();
+    return items.filter((item) => {
+        const key = [
+            item.makeTarget,
+            item.deployTag,
+            item.deployBundle,
+            item.deployHosts,
+            item.deployEnv,
+        ].join('|');
+        if (seen.has(key)) {
+            return false;
+        }
+        seen.add(key);
+        return true;
+    });
+}
+function shellEscape(value) {
+    return `'${value.replace(/'/g, "'\\''")}'`;
+}
 function extractRecap(stdout) {
     const lines = stdout.split('\n');
     const idx = lines.findIndex((l) => l.includes('PLAY RECAP'));
@@ -331,6 +446,7 @@ function extractRecap(stdout) {
     return lines.slice(-10).join('\n');
 }
 const STAGING_BASE = path.join(os.tmpdir(), 'hubot-deploy');
+const DEPLOY_CACHE_BASE = path.join(os.tmpdir(), 'deploy');
 function cleanup(file, dir) {
     try {
         (0, fs_1.unlinkSync)(file);

--- a/src/deploy.ts
+++ b/src/deploy.ts
@@ -10,7 +10,16 @@
 //   from the text and deploys latest.
 
 import { createHash } from 'crypto';
-import { createReadStream, createWriteStream, mkdirSync, unlinkSync, rmdirSync } from 'fs';
+import {
+  copyFileSync,
+  createReadStream,
+  createWriteStream,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmdirSync,
+  unlinkSync,
+} from 'fs';
 import * as https from 'https';
 import * as os from 'os';
 import * as path from 'path';
@@ -183,6 +192,28 @@ interface ValidatedRelease {
   assetName: string;
 }
 
+interface DeployManifestBundle {
+  name: string;
+  path: string;
+  target: string;
+  hosts: string[];
+}
+
+interface DeployManifest {
+  app: string;
+  bundles: DeployManifestBundle[];
+}
+
+interface DeployPlanItem {
+  makeTarget: string;
+  deployTag: string;
+  artifactUrl: string;
+  deployBundle: string;
+  deployHosts: string;
+  deployEnv: string;
+  displayName: string;
+}
+
 async function validateRelease(
   repo: string,
   tag: string,
@@ -290,9 +321,16 @@ module.exports = (robot: any) => {
         `Tag: \`${tag}\` | Commit: \`${commitSha.slice(0, 8)}\` | SHA256: \`${fileHash.slice(0, 12)}...\``,
       );
 
-      // Pass the api.github.com asset URL (not the human-facing releaseUrl)
-      // because deploy.sh rejects anything outside api.github.com/repos/sonarmd/*.
-      await runDeploy(msg, robot, identifier, env, tag, assetUrl);
+      const deployPlan = await resolveDeployPlan({
+        identifier,
+        env,
+        tag,
+        artifactUrl: assetUrl,
+        assetPath,
+        stagingDir,
+      });
+
+      await runDeployPlan(msg, robot, identifier, deployPlan);
       cleanup(assetPath, stagingDir);
       return;
     }
@@ -315,37 +353,47 @@ module.exports = (robot: any) => {
     robot.logger.info(`[deploy] fallback | env: ${env} | app: ${identifier} | ${releaseUrl}`);
     msg.send(`:rocket: Deploying \`${repo}\` → \`${env}\` (no structured tag — using latest)`);
 
-    await runDeploy(msg, robot, identifier, env, tag, releaseUrl);
+    await runDeployPlan(msg, robot, identifier, [
+      createDefaultDeployPlanItem(identifier, env, tag, releaseUrl),
+    ]);
   });
 };
 
 // ── Deploy execution ─────────────────────────────────────────────────────────
 
-async function runDeploy(
+async function runDeployPlan(
   msg: any,
   robot: any,
   identifier: string,
-  env: string,
-  tag: string,
-  artifactUrl: string,
+  deployPlan: DeployPlanItem[],
+): Promise<void> {
+  for (const item of deployPlan) {
+    await runDeployItem(msg, robot, identifier, item);
+  }
+}
+
+async function runDeployItem(
+  msg: any,
+  robot: any,
+  identifier: string,
+  planItem: DeployPlanItem,
 ): Promise<void> {
   try {
     // deploy.sh contract (7 positional args — strict):
     //   <caller> <make_target> <deploy_tag> <artifact_url> <deploy_bundle> <deploy_hosts> <deploy_env>
-    //
-    // make_target follows the ${identifier}_${env} convention (e.g. cdk_stg,
-    // api_prd). deploy_bundle and deploy_hosts are unused by the cdk_*
-    // Makefile targets, so we pass empty strings. Non-cdk apps that DO
-    // consume those will need bundle/hosts added to the Slack trigger
-    // contract — out of scope for this fix.
-    const makeTarget = `${identifier}_${env}`;
-    const deployTag  = tag || 'latest';
-    const deployBundle = '';
-    const deployHosts  = '';
+    const {
+      makeTarget,
+      deployTag,
+      artifactUrl,
+      deployBundle,
+      deployHosts,
+      deployEnv,
+      displayName,
+    } = planItem;
 
     // Use execFile-style quoting via shell-escaping so empty positional
     // args survive. Quote every arg defensively.
-    const escape = (s: string) => `'${s.replace(/'/g, "'\\''")}'`;
+    const escape = shellEscape;
     const cmd = [
       'sudo', '--non-interactive',
       DEPLOY_SCRIPT,
@@ -355,7 +403,7 @@ async function runDeploy(
       escape(artifactUrl),
       escape(deployBundle),
       escape(deployHosts),
-      escape(env),
+      escape(deployEnv),
     ].join(' ');
 
     robot.logger.info(`[deploy] exec: ${cmd}`);
@@ -366,20 +414,185 @@ async function runDeploy(
 
     const recap = extractRecap(stdout);
     msg.send(
-      `:white_check_mark: Deploy SUCCESS — \`${identifier}\` \`${tag || 'latest'}\` → \`${env}\`\n` +
+      `:white_check_mark: Deploy SUCCESS — \`${identifier}\` \`${deployTag || 'latest'}\` → \`${deployEnv}\` (${displayName})\n` +
       `\`\`\`\n${recap}\n\`\`\``,
     );
   } catch (err: any) {
     robot.logger.error(`[deploy] failed: ${err.message}`);
     const tail = (err.stdout ?? '').split('\n').slice(-30).join('\n');
     msg.send(
-      `:x: Deploy FAILED — \`${identifier}\` \`${tag || 'latest'}\` → \`${env}\`\n` +
+      `:x: Deploy FAILED — \`${identifier}\` \`${planItem.deployTag || 'latest'}\` → \`${planItem.deployEnv}\` (${planItem.displayName})\n` +
       `\`\`\`\n${tail || err.stderr || err.message}\n\`\`\``,
     );
   }
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
+
+async function resolveDeployPlan(params: {
+  identifier: string;
+  env: string;
+  tag: string;
+  artifactUrl: string;
+  assetPath: string;
+  stagingDir: string;
+}): Promise<DeployPlanItem[]> {
+  const fallbackItem = createDefaultDeployPlanItem(
+    params.identifier,
+    params.env,
+    params.tag,
+    params.artifactUrl,
+  );
+
+  const manifest = await readReleaseManifest(params.assetPath, params.stagingDir);
+  if (manifest) {
+    const manifestPlan = await resolveManifestDeployPlan({
+      env: params.env,
+      tag: params.tag,
+      artifactUrl: params.artifactUrl,
+      stagingDir: params.stagingDir,
+    }, manifest);
+    if (manifestPlan.length > 0) {
+      return manifestPlan;
+    }
+  }
+
+  return [fallbackItem];
+}
+
+function createDefaultDeployPlanItem(
+  identifier: string,
+  env: string,
+  tag: string,
+  artifactUrl: string,
+): DeployPlanItem {
+  return {
+    makeTarget: `${identifier}_${env}`,
+    deployTag: tag || 'latest',
+    artifactUrl,
+    deployBundle: '',
+    deployHosts: '',
+    deployEnv: env,
+    displayName: `${identifier}_${env}`,
+  };
+}
+
+async function resolveManifestDeployPlan(params: {
+  env: string;
+  tag: string;
+  artifactUrl: string;
+  stagingDir: string;
+}, manifest: DeployManifest): Promise<DeployPlanItem[]> {
+  const extractedReleaseDir = path.join(params.stagingDir, 'release');
+  const planItems: DeployPlanItem[] = [];
+
+  for (const bundle of manifest.bundles.filter(requiresPreparedDeployTarget)) {
+    const bundleArchive = path.join(extractedReleaseDir, `${bundle.name}.tar.gz`);
+    if (!existsSync(bundleArchive)) {
+      throw new Error(`Missing bundle archive for ${bundle.name}`);
+    }
+
+    const bundleExtractDir = path.join(params.stagingDir, `bundle-${bundle.name}`);
+    await extractTarball(bundleArchive, bundleExtractDir);
+
+    const bundleRoot = path.join(bundleExtractDir, normalizeBundleRoot(bundle.path));
+
+    for (const host of bundle.hosts) {
+      const deployHost = renderDeployHost(host, params.env);
+      const templateSource = path.join(bundleRoot, `${deployHost}.template.json`);
+      if (!existsSync(templateSource)) {
+        throw new Error(`Missing CDK template for ${deployHost} in ${bundle.name}`);
+      }
+
+      const preparedDir = path.join(DEPLOY_CACHE_BASE, params.tag, deployHost, params.env);
+      mkdirSync(preparedDir, { recursive: true });
+      copyFileSync(templateSource, path.join(preparedDir, `${deployHost}.template.json`));
+
+      planItems.push({
+        makeTarget: `${bundle.target}_${params.env}`,
+        deployTag: params.tag || 'latest',
+        artifactUrl: params.artifactUrl,
+        deployBundle: bundle.name,
+        deployHosts: deployHost,
+        deployEnv: params.env,
+        displayName: `${bundle.name}:${deployHost}`,
+      });
+    }
+  }
+
+  return dedupeDeployPlan(planItems);
+}
+
+async function readReleaseManifest(
+  assetPath: string,
+  stagingDir: string,
+): Promise<DeployManifest | null> {
+  const extractedReleaseDir = path.join(stagingDir, 'release');
+  const manifestPath = path.join(extractedReleaseDir, 'deploy.json');
+
+  if (!existsSync(manifestPath)) {
+    await extractTarball(assetPath, extractedReleaseDir);
+  }
+
+  if (!existsSync(manifestPath)) {
+    return null;
+  }
+
+  return readDeployManifest(manifestPath);
+}
+
+function readDeployManifest(filePath: string): DeployManifest {
+  const manifest = JSON.parse(readFileSync(filePath, 'utf8')) as DeployManifest;
+  if (!Array.isArray(manifest.bundles)) {
+    throw new Error(`Invalid deploy manifest at ${filePath}`);
+  }
+
+  return manifest;
+}
+
+async function extractTarball(archivePath: string, destination: string): Promise<void> {
+  mkdirSync(destination, { recursive: true });
+  await exec(
+    `tar -xzf ${shellEscape(archivePath)} -C ${shellEscape(destination)}`,
+    { timeout: DEPLOY_TIMEOUT },
+  );
+}
+
+function normalizeBundleRoot(bundlePath: string): string {
+  return path.basename(bundlePath.replace(/[\\/]+$/, ''));
+}
+
+function renderDeployHost(host: string, env: string): string {
+  return host.replace(/\{env\}/g, env);
+}
+
+function requiresPreparedDeployTarget(bundle: DeployManifestBundle): boolean {
+  return bundle.target === 'cdk';
+}
+
+function dedupeDeployPlan(items: DeployPlanItem[]): DeployPlanItem[] {
+  const seen = new Set<string>();
+  return items.filter((item) => {
+    const key = [
+      item.makeTarget,
+      item.deployTag,
+      item.deployBundle,
+      item.deployHosts,
+      item.deployEnv,
+    ].join('|');
+
+    if (seen.has(key)) {
+      return false;
+    }
+
+    seen.add(key);
+    return true;
+  });
+}
+
+function shellEscape(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
 
 function extractRecap(stdout: string): string {
   const lines = stdout.split('\n');
@@ -389,6 +602,7 @@ function extractRecap(stdout: string): string {
 }
 
 const STAGING_BASE = path.join(os.tmpdir(), 'hubot-deploy');
+const DEPLOY_CACHE_BASE = path.join(os.tmpdir(), 'deploy');
 
 function cleanup(file: string, dir: string): void {
   try { unlinkSync(file); } catch { /* already gone */ }


### PR DESCRIPTION
### Why I think this will resolve cdk deploy?

The issue was not with the generic deploy trigger itself, but with the amount of context being passed to the CDK deploy path. The existing Hubot handoff only forwarded make_target, tag, and artifact_url, which is enough for the other services because their deploy flow already works with that contract. CDK was the exception because its downstream deploy logic needs stack-specific context, especially deploy_hosts, to resolve the correct CloudFormation template and stack name.

The fix was implemented in Hubot, not by changing the shared workflow or the other service paths. Hubot now performs the extra resolution only when the release artifact contains deploy metadata that requires prepared stack-specific handling. For normal services, the deploy call remains the same as before. For CDK, Hubot reads the bundled release metadata, resolves the target stack information, and provides the missing context that the downstream CDK deploy logic expects.

That is why this change does not break other deploys: API, frontend, and mobile still invoke deploy.sh with the same contract they used before, while CDK now gets the additional stack-level information it was missing.

### Copilot Summary

This pull request refactors and extends the deployment logic to support structured deploy manifests, enabling more flexible and robust multi-bundle deployments. The main changes introduce a new manifest-driven deployment flow, improved planning and execution of deploy steps, and several helper utilities to support this functionality.

**Key changes include:**

### Manifest-driven Deployment

* Introduced `DeployManifest` and `DeployManifestBundle` interfaces, and added logic to parse and use a `deploy.json` manifest file from release artifacts to drive deployments. This allows deployments to be defined declaratively in the release artifact. [[1]](diffhunk://#diff-56b601f2d15e50588c241aa410e2e33371e89501f907be2d3f9a377e11e3ed70R195-R216) [[2]](diffhunk://#diff-56b601f2d15e50588c241aa410e2e33371e89501f907be2d3f9a377e11e3ed70L369-R596)
* Added `resolveDeployPlan`, `resolveManifestDeployPlan`, and related helpers to generate a list of deploy steps (`DeployPlanItem[]`) from the manifest, supporting multi-bundle and multi-host deployments.

### Deployment Execution Refactor

* Replaced the previous `runDeploy` function with `runDeployPlan` and `runDeployItem`, allowing the system to execute multiple deploy steps as determined by the deploy plan, rather than a single static deploy step.
* Updated success and failure messaging to include more detailed context (such as display name and deploy environment) for each deploy plan item.

### Helper Functions and Utilities

* Added utilities for extracting and preparing deployment bundles, normalizing paths, rendering hostnames, deduplicating deploy steps, and safely shell-escaping arguments.
* Added `DEPLOY_CACHE_BASE` to cache prepared deployment artifacts per environment and tag.

### Dependency and Import Updates

* Expanded imports from `fs` to include additional file operations needed for manifest and bundle handling.

These changes collectively enable the deployment system to support more complex, manifest-driven deployment scenarios, improve modularity, and lay the groundwork for further extensibility.